### PR TITLE
Make it possible to implement linear open loop CAR biquadratic filters

### DIFF
--- a/matlab/CARFAC_Rational_Functions.m
+++ b/matlab/CARFAC_Rational_Functions.m
@@ -41,6 +41,7 @@ if isfield(CF.ears(ear), 'CAR_state')
   r = r1 + zB;
 else
   zB = 0;  % HIGH-level linear condition by default
+  r = r1;
 end
 
 relative_undamping = zB ./ zr;

--- a/matlab/CARFAC_Rational_Functions.m
+++ b/matlab/CARFAC_Rational_Functions.m
@@ -1,0 +1,55 @@
+% Copyright 2012 The CARFAC Authors. All Rights Reserved.
+% Author: Richard F. Lyon
+%
+% This file is part of an implementation of Lyon's cochlear model:
+% "Cascade of Asymmetric Resonators with Fast-Acting Compression"
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%     http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+
+function [stage_numerators, stage_denominators] = ...
+  CARFAC_Rational_Functions(CF, ear)
+% function [stage_z_numerators, stage_z_denominators] = ...
+%   CARFAC_Rational_Functions(CF, ear)
+% Return transfer functions of all stages as rational functions.
+
+if nargin < 2
+  ear = 1;
+end
+
+n_ch = CF.n_ch;
+coeffs = CF.ears(ear).CAR_coeffs;
+
+a0 = coeffs.a0_coeffs;
+c0 = coeffs.c0_coeffs;
+zr = coeffs.zr_coeffs;
+
+% get r, adapted if we have state:
+r1 =  coeffs.r1_coeffs;  % max-damping condition
+if isfield(CF.ears(ear), 'CAR_state')
+  state = CF.ears(ear).CAR_state;
+  zB = state.zB_memory; % current delta-r from undamping
+  r = r1 + zB;
+else
+  zB = 0;  % HIGH-level linear condition by default
+end
+
+relative_undamping = zB ./ zr;
+g = CARFAC_Stage_g(coeffs, relative_undamping);
+a = a0 .* r;
+c = c0 .* r;
+r2 = r .* r;
+h = coeffs.h_coeffs;
+
+stage_denominators = [ones(n_ch, 1), -2 * a, r2];
+stage_numerators = [g .* ones(n_ch, 1), g .* (-2 * a + h .* c), g .* r2];
+

--- a/matlab/CARFAC_Test.m
+++ b/matlab/CARFAC_Test.m
@@ -33,6 +33,7 @@ status = status | test_AGC_steady_state(do_plots);
 status = status | test_whole_carfac(do_plots);
 status = status | test_delay_buffer(do_plots);
 status = status | test_OHC_health(do_plots);
+status = status | test_CAR_biquad(do_plots);
 report_status(status, 'CARFAC_Test', 1)
 return
 
@@ -649,6 +650,76 @@ end
 report_status(status, 'test_OHC_health')
 return
 
+function status = test_CAR_biquad(do_plots)
+% Test the linear open loop biquadratic implementation of the CAR filters
+status = 0; % start in the passing state
+n_ears=1;
+fs=22050;
+[~, b, a]=CAR_Design(n_ears, fs);
+b=b(:, :, 1); % only look at the first ear for now
+a=a(:, :, 1);
+M=size(b, 1);
+N=fs; % take a one second response
+% find the impulse response
+x=zeros(N, 1);
+x(1)=1;
+y(:, 1)=filter(b(1, :), a(1, :), x);
+for m=2:M % ripple through the cascade
+	y(:, m)=filter(b(m, :), a(m, :), y(:, m-1));
+end
+
+CF=CARFAC_Design(n_ears, fs);
+CF.open_loop = 1;  % For measuring impulse response.
+CF.linear_car = 1;  % For measuring impulse response.
+CF = CARFAC_Init(CF);
+[~, CF, bm_initial] = CARFAC_Run_Segment(CF, x);
+
+if do_plots
+	Y=fft(y);
+	
+	f=linspace(0, fs, N+1); f(end)=[];
+	
+	figure(1); clf
+	semilogx(f, 20*log10(abs(Y))); grid on;
+	xlabel('f (Hz)'); ylabel('dB')
+	title('CAR filters')
+	% print -depsc /tmp/CAR.DFT.eps
+	
+	Yref=fft(bm_initial);
+	
+	figure(2); clf
+	semilogx(f,20*log10(abs(Yref))); grid on;
+	xlabel('f (Hz)'); ylabel('dB')
+	title('CARFAC reference')
+	% print -depsc /tmp/CARFAC.DFT.eps
+	
+	figure(3); clf
+	semilogx(y); grid on;
+	xlabel('sample (n)'); ylabel('amp.')
+	title('CAR filters')
+	% print -depsc /tmp/CAR.t.eps
+	
+	figure(4); clf
+	semilogx(bm_initial); grid on;
+	xlabel('sample (n)'); ylabel('amp.')
+	title('CARFAC filters')
+	% print -depsc /tmp/CARFAC.t.eps
+	
+	figure(5); clf
+	semilogx(bm_initial-y); grid on;
+	xlabel('sample (n)'); ylabel('error')
+	title('Error between the CARFAC and biquad filters')
+	% print -depsc /tmp/CARFAC.CAR.error.t.eps
+end
+
+tol=1e-10;
+if (rms(bm_initial - y) > tol)
+	status = 1; % indicate a test fail
+	fprintf(1, 'CAR biquad implementation is greater then %e from the cross coupled CAR implementation.\n', tol)
+end
+
+report_status(status, 'test_car')
+return
 
 function cf_amp_bw = find_peak_response(freqs, db_gains, bw_level)
 %Returns center frequency, amplitude at this point, and the 3dB width."""

--- a/matlab/CARFAC_Transfer_Functions.m
+++ b/matlab/CARFAC_Transfer_Functions.m
@@ -95,43 +95,6 @@ gains = (numerators * zz) ./ (denominators * zz);
 
 
 
-function [stage_numerators, stage_denominators] = ...
-  CARFAC_Rational_Functions(CF, ear)
-% function [stage_z_numerators, stage_z_denominators] = ...
-%   CARFAC_Rational_Functions(CF, ear)
-% Return transfer functions of all stages as rational functions.
-
-if nargin < 2
-  ear = 1;
-end
-
-n_ch = CF.n_ch;
-coeffs = CF.ears(ear).CAR_coeffs;
-
-a0 = coeffs.a0_coeffs;
-c0 = coeffs.c0_coeffs;
-zr = coeffs.zr_coeffs;
-
-% get r, adapted if we have state:
-r1 =  coeffs.r1_coeffs;  % max-damping condition
-if isfield(CF.ears(ear), 'CAR_state')
-  state = CF.ears(ear).CAR_state;
-  zB = state.zB_memory; % current delta-r from undamping
-  r = r1 + zB;
-else
-  zB = 0;  % HIGH-level linear condition by default
-end
-
-relative_undamping = zB ./ zr;
-g = CARFAC_Stage_g(coeffs, relative_undamping);
-a = a0 .* r;
-c = c0 .* r;
-r2 = r .* r;
-h = coeffs.h_coeffs;
-
-stage_denominators = [ones(n_ch, 1), -2 * a, r2];
-stage_numerators = [g .* ones(n_ch, 1), g .* (-2 * a + h .* c), g .* r2];
-
 
 %% example
 % CF = CARFAC_Design

--- a/matlab/CAR_Design.m
+++ b/matlab/CAR_Design.m
@@ -60,7 +60,7 @@ CF = CARFAC_Init(CF);
 
 for ear=1:CF.n_ears
 	% This method 
-	r1=CF.ears(ear).CAR_coeffs.r1_coeffs
+	r1=CF.ears(ear).CAR_coeffs.r1_coeffs;
 	a0=CF.ears(ear).CAR_coeffs.a0_coeffs;
 	h=CF.ears(ear).CAR_coeffs.h_coeffs;
 	g=CF.ears(ear).CAR_coeffs.g0_coeffs;

--- a/matlab/CAR_Design.m
+++ b/matlab/CAR_Design.m
@@ -1,5 +1,5 @@
 % Copyright 2012 The CARFAC Authors. All Rights Reserved.
-% Author: Matt R. Flax, setup taken from Richard F. Lyon's CAR_Design.m
+% Author: Matt R. Flax, setup taken from Richard F. Lyon's CARFAC_Design.m
 %
 % This file is part of an implementation of Lyon's cochlear model:
 % "Cascade of Asymmetric Resonators with Fast-Acting Compression"
@@ -27,68 +27,83 @@ function [CF, b, a] = CAR_Design(n_ears, fs, CF_CAR_params)
 % CF_CAR_params bundles all the pole-zero filter cascade parameters
 
 if nargin == 0
-    CAR_Design_Test;
-    return
+	CAR_Design_Test;
+	return
 end
 
 if nargin < 1
-  n_ears = 1;  % if more than 1, make them identical channels;
-  % then modify the design if necessary for different reasons
+	n_ears = 1;  % if more than 1, make them identical channels;
+	% then modify the design if necessary for different reasons
 end
 
 if nargin < 2
-  fs = 22050;
+	fs = 22050;
 end
 
 if nargin < 3
-  CF_CAR_params = struct( ...
-    'velocity_scale', 0.1, ...  % for the velocity nonlinearity
-    'v_offset', 0.04, ...  % offset gives a quadratic part
-    'min_zeta', 0.10, ... % minimum damping factor in mid-freq channels
-    'max_zeta', 0.35, ... % maximum damping factor in mid-freq channels
-    'first_pole_theta', 0.85*pi, ...
-    'zero_ratio', sqrt(2), ... % how far zero is above pole
-    'high_f_damping_compression', 0.5, ... % 0 to 1 to compress zeta
-    'ERB_per_step', 0.5, ... % assume G&M's ERB formula
-    'min_pole_Hz', 30, ...
-    'ERB_break_freq', 165.3, ...  % 165.3 is Greenwood map's break freq.
-    'ERB_Q', 1000/(24.7*4.37));  % Glasberg and Moore's high-cf ratio
+	CF_CAR_params = struct( ...
+		'velocity_scale', 0.1, ...  % for the velocity nonlinearity
+		'v_offset', 0.04, ...  % offset gives a quadratic part
+		'min_zeta', 0.10, ... % minimum damping factor in mid-freq channels
+		'max_zeta', 0.35, ... % maximum damping factor in mid-freq channels
+		'first_pole_theta', 0.85*pi, ...
+		'zero_ratio', sqrt(2), ... % how far zero is above pole
+		'high_f_damping_compression', 0.5, ... % 0 to 1 to compress zeta
+		'ERB_per_step', 0.5, ... % assume G&M's ERB formula
+		'min_pole_Hz', 30, ...
+		'ERB_break_freq', 165.3, ...  % 165.3 is Greenwood map's break freq.
+		'ERB_Q', 1000/(24.7*4.37));  % Glasberg and Moore's high-cf ratio
 end
 
 CF = CARFAC_Design(n_ears, fs, CF_CAR_params);
 
 % reconstruct poles and zeros from section 16.2 in the book
 for ear=1:CF.n_ears
-  [r, a0, hc0, g]=deal(CF.ears(ear).CAR_coeffs.r1_coeffs, CF.ears(ear).CAR_coeffs.a0_coeffs, CF.ears(ear).CAR_coeffs.h_coeffs, CF.ears(ear).CAR_coeffs.g0_coeffs);
-  for m=1:CF.n_ch
-    p=r(m)*(a0(m) + j*sin(acos(a0(m))));
-    o=a0(m)-hc0(m)/2;
-    o=o+j*sin(acos(o));
-    o=r(m)*o;
-    p=[p conj(p)];
-    o=[o conj(o)];
-    a(m,:)=poly(p);
-%     b(m,:)=g(m)*poly(o);
-      b(m,:)=g(m)*poly(o);
-  end
+	[r, a0, hc0, g]=deal(CF.ears(ear).CAR_coeffs.r1_coeffs, CF.ears(ear).CAR_coeffs.a0_coeffs, CF.ears(ear).CAR_coeffs.h_coeffs, CF.ears(ear).CAR_coeffs.g0_coeffs);
+	for m=1:CF.n_ch
+		p=r(m)*(a0(m) + j*sin(acos(a0(m))));
+		o=a0(m)-hc0(m)/2;
+		o=r(m)*(o+j*sin(acos(o)));
+		
+		p=[p conj(p)]; % complex conjugate poles and zeros
+		o=[o conj(o)];
+		
+		a(m,:)=poly(p); % get the a and b polynomials
+		b(m,:)=g(m)*poly(o); % apply the gain to the numerator
+	end
 end
 end
 
 function CAR_Design_Test
-    n_ears=1;
-    fs=22050;
-    [~, b, a]=CAR_Design(n_ears, fs);
-    M=size(b,1);
-    N=fs;
-    % find the impulse response
-    x=zeros(N,M);
-    x(1,:)=1;
-    for m=1:M
-        y(:,m)=filter(b(m,:),a(m,:),x(:,m));
-    end
-    Y=fft(y);
-    f=linspace(0,fs,N+1); f(end)=[];
-    semilogx(f,20*log10(abs(Y))); grid on;
-    xlabel('f (Hz)'); ylabel('dB')
+n_ears=1;
+fs=22050;
+[~, b, a]=CAR_Design(n_ears, fs);
+M=size(b,1);
+N=fs;
+% find the impulse response
+x=zeros(N,1);
+x(1)=1;
+for m=1:M
+	y(:,m)=filter(b(m,:),a(m,:),x);
 end
+Y=fft(y);
+f=linspace(0,fs,N+1); f(end)=[];
 
+figure(1); clf
+semilogx(f,20*log10(abs(Y))); grid on;
+xlabel('f (Hz)'); ylabel('dB')
+title('CAR filters')
+
+CF=CARFAC_Design(n_ears, fs);
+CF.open_loop = 1;  % For measuring impulse response.
+CF.linear_car = 1;  % For measuring impulse response.
+CF = CARFAC_Init(CF);
+[~, CF, bm_initial] = CARFAC_Run_Segment(CF, x);
+
+Yref=fft(bm_initial);
+
+figure(2); clf
+semilogx(f,20*log10(abs(Yref))); grid on;
+xlabel('f (Hz)'); ylabel('dB')
+title('CARFAC reference')
+end

--- a/matlab/CAR_Design.m
+++ b/matlab/CAR_Design.m
@@ -60,15 +60,16 @@ CF = CARFAC_Init(CF);
 
 for ear=1:CF.n_ears
 	% This method 
-	r1=CF.ears(ear).CAR_coeffs.r1_coeffs;
-	a0=CF.ears(ear).CAR_coeffs.a0_coeffs;
-	h=CF.ears(ear).CAR_coeffs.h_coeffs;
-	g=CF.ears(ear).CAR_coeffs.g0_coeffs;
-	c=CF.ears(ear).CAR_coeffs.c0_coeffs;
+	CAR_coeffs = CF.ears(ear).CAR_coeffs;
+	r1=CAR_coeffs.r1_coeffs;
+	a0=CAR_coeffs.a0_coeffs;
+	h=CAR_coeffs.h_coeffs;
+	g=CAR_coeffs.g0_coeffs;
+	c=CAR_coeffs.c0_coeffs;
 	zB = CF.ears(ear).CAR_state.zB_memory; % current delta-r from undamping
 	r = r1 + zB;
-	b(:,:, ear)=g.*[ones(CF.n_ch,1) (h.*r.*c-2*r.*a0) (r.^2.*(c.^2+a0.^2))];
-	a(:,:, ear)=[ones(CF.n_ch,1) -2*r.*a0 r.^2.*(c.^2+a0.^2)];
+	b(:, :, ear)=g.*[ones(CF.n_ch, 1) (h.*r.*c - 2*r.*a0) (r.^2.*(c.^2 + a0.^2))];
+	a(:, :, ear)=[ones(CF.n_ch, 1) -2*r.*a0 r.^2.*(c.^2 + a0.^2)];
 	
 	% This method uses CARFAC_Rational_Functions to generate the IIR filter coefficients
  	% [b(:,:,ear), a(:,:,ear), g(:,ear)] = CARFAC_Rational_Functions(CF, ear);
@@ -79,23 +80,23 @@ function CAR_Design_Test
 n_ears=1;
 fs=22050;
 [~, b, a]=CAR_Design(n_ears, fs);
-b=b(:,:,1); % only look at the first ear for now
-a=a(:,:,1);
-M=size(b,1);
+b=b(:, :, 1); % only look at the first ear for now
+a=a(:, :, 1);
+M=size(b, 1);
 N=fs; % take a one second response
 % find the impulse response
-x=zeros(N,1);
+x=zeros(N, 1);
 x(1)=1;
-y(:,1)=filter(b(1,:),a(1,:),x);
+y(:, 1)=filter(b(1, :), a(1, :), x);
 for m=2:M % ripple through the cascade
-	y(:,m)=filter(b(m,:),a(m,:),y(:,m-1));
+	y(:, m)=filter(b(m, :), a(m, :), y(:, m-1));
 end
 Y=fft(y);
 
-f=linspace(0,fs,N+1); f(end)=[];
+f=linspace(0, fs, N+1); f(end)=[];
 
 figure(1); clf
-semilogx(f,20*log10(abs(Y))); grid on;
+semilogx(f, 20*log10(abs(Y))); grid on;
 xlabel('f (Hz)'); ylabel('dB')
 title('CAR filters')
 % print -depsc /tmp/CAR.DFT.eps

--- a/matlab/CAR_Design.m
+++ b/matlab/CAR_Design.m
@@ -1,0 +1,94 @@
+% Copyright 2012 The CARFAC Authors. All Rights Reserved.
+% Author: Matt R. Flax, setup taken from Richard F. Lyon's CAR_Design.m
+%
+% This file is part of an implementation of Lyon's cochlear model:
+% "Cascade of Asymmetric Resonators with Fast-Acting Compression"
+%
+% Licensed under the Apache License, Version 2.0 (the "License");
+% you may not use this file except in compliance with the License.
+% You may obtain a copy of the License at
+%
+%     http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+% See the License for the specific language governing permissions and
+% limitations under the License.
+
+function [CF, b, a] = CAR_Design(n_ears, fs, CF_CAR_params)
+% function CF = CAR_Design(n_ears, fs, CF_CAR_params)
+%
+% This function designs the CAR (Cascade of Asymmetric Resonators);
+% that is, it take bundles of parameters and
+% computes all the filter coefficients needed to run it.
+%
+% fs is sample rate (per second)
+% CF_CAR_params bundles all the pole-zero filter cascade parameters
+
+if nargin == 0
+    CAR_Design_Test;
+    return
+end
+
+if nargin < 1
+  n_ears = 1;  % if more than 1, make them identical channels;
+  % then modify the design if necessary for different reasons
+end
+
+if nargin < 2
+  fs = 22050;
+end
+
+if nargin < 3
+  CF_CAR_params = struct( ...
+    'velocity_scale', 0.1, ...  % for the velocity nonlinearity
+    'v_offset', 0.04, ...  % offset gives a quadratic part
+    'min_zeta', 0.10, ... % minimum damping factor in mid-freq channels
+    'max_zeta', 0.35, ... % maximum damping factor in mid-freq channels
+    'first_pole_theta', 0.85*pi, ...
+    'zero_ratio', sqrt(2), ... % how far zero is above pole
+    'high_f_damping_compression', 0.5, ... % 0 to 1 to compress zeta
+    'ERB_per_step', 0.5, ... % assume G&M's ERB formula
+    'min_pole_Hz', 30, ...
+    'ERB_break_freq', 165.3, ...  % 165.3 is Greenwood map's break freq.
+    'ERB_Q', 1000/(24.7*4.37));  % Glasberg and Moore's high-cf ratio
+end
+
+CF = CARFAC_Design(n_ears, fs, CF_CAR_params);
+
+% reconstruct poles and zeros from section 16.2 in the book
+for ear=1:CF.n_ears
+  [r, a0, hc0, g]=deal(CF.ears(ear).CAR_coeffs.r1_coeffs, CF.ears(ear).CAR_coeffs.a0_coeffs, CF.ears(ear).CAR_coeffs.h_coeffs, CF.ears(ear).CAR_coeffs.g0_coeffs);
+  for m=1:CF.n_ch
+    p=r(m)*(a0(m) + j*sin(acos(a0(m))));
+    o=a0(m)-hc0(m)/2;
+    o=o+j*sin(acos(o));
+    o=r(m)*o;
+    p=[p conj(p)];
+    o=[o conj(o)];
+    a(m,:)=poly(p);
+%     b(m,:)=g(m)*poly(o);
+      b(m,:)=g(m)*poly(o);
+  end
+end
+end
+
+function CAR_Design_Test
+    n_ears=1;
+    fs=22050;
+    [~, b, a]=CAR_Design(n_ears, fs);
+    M=size(b,1);
+    N=fs;
+    % find the impulse response
+    x=zeros(N,M);
+    x(1,:)=1;
+    for m=1:M
+        y(:,m)=filter(b(m,:),a(m,:),x(:,m));
+    end
+    Y=fft(y);
+    f=linspace(0,fs,N+1); f(end)=[];
+    semilogx(f,20*log10(abs(Y))); grid on;
+    xlabel('f (Hz)'); ylabel('dB')
+end
+

--- a/matlab/CAR_Design.m
+++ b/matlab/CAR_Design.m
@@ -56,6 +56,7 @@ if nargin < 3
 end
 
 CF = CARFAC_Design(n_ears, fs, CF_CAR_params);
+CF = CARFAC_Init(CF);
 
 for ear=1:CF.n_ears
 	if 1 % use CARFAC_Rational_Functions to generate the IIR filter coefficients

--- a/matlab/CAR_Design.m
+++ b/matlab/CAR_Design.m
@@ -67,10 +67,8 @@ for ear=1:CF.n_ears
 	c=CF.ears(ear).CAR_coeffs.c0_coeffs;
 	zB = CF.ears(ear).CAR_state.zB_memory; % current delta-r from undamping
 	r = r1 + zB;
-	for m=1:CF.n_ch
-		b(m,:, ear)=g(m)*[1 (h(m)*r(m)*c(m)-2*r(m)*a0(m)) (r(m).^2*(c(m).^2+a0(m).^2))];
-		a(m,:, ear)=[1 -2*r(m)*a0(m) r(m).^2*(c(m).^2+a0(m).^2)];
-	end
+	b(:,:, ear)=g.*[ones(CF.n_ch,1) (h.*r.*c-2*r.*a0) (r.^2.*(c.^2+a0.^2))];
+	a(:,:, ear)=[ones(CF.n_ch,1) -2*r.*a0 r.^2.*(c.^2+a0.^2)];
 	
 	% This method uses CARFAC_Rational_Functions to generate the IIR filter coefficients
  	% [b(:,:,ear), a(:,:,ear), g(:,ear)] = CARFAC_Rational_Functions(CF, ear);

--- a/matlab/CAR_Design.m
+++ b/matlab/CAR_Design.m
@@ -116,4 +116,15 @@ figure(2); clf
 semilogx(f,20*log10(abs(Yref))); grid on;
 xlabel('f (Hz)'); ylabel('dB')
 title('CARFAC reference')
+
+figure(3); clf
+semilogx(y); grid on;
+xlabel('sample (n)'); ylabel('amp.')
+title('CAR filters')
+
+figure(4); clf
+semilogx(bm_initial); grid on;
+xlabel('sample (n)'); ylabel('amp.')
+title('CARFAC filters')
+
 end


### PR DESCRIPTION
Linear open loop CAR filters are useful as nice analogues of static psychoacoustic filters.
This set of patches adds the CAR_Design.m script which generates linear open loop CAR filters. These filters can be generated using either the CARFAC_Rational_Functions.m script (which was extracted from CARFAC_Transfer_Functions.m) or these biquadratic coefficients can be estimated using the CF.ears(ear).CAR_coeffs variables and the CF.ears(ear).CAR_state.zB_memory variable.