### PR TITLE
fixed an error with ihc_hypers.ihc_style=0

### DIFF
--- a/python/jax/carfac.py
+++ b/python/jax/carfac.py
@@ -1967,7 +1967,7 @@ def ihc_step(
   ihc_hypers = hypers.ears[ear].ihc
   v_recep = jnp.zeros(hypers.ears[ear].car.n_ch)
   if ihc_hypers.ihc_style == 0:
-    ihc_out = jnp.min(2, jnp.max(0, bm_out))  # pytype: disable=wrong-arg-types  # jnp-type
+    ihc_out = jnp.minimum(2, jnp.maximum(0, bm_out))  # pytype: disable=wrong-arg-types  # jnp-type
     #  limit it for stability
   else:
     conductance = ihc_detect(bm_out)  # rectifying nonlinearity


### PR DESCRIPTION
jnp.min and jnp.max only find the min and max for one array. To find the min and max between two components, we need to use jnp.minimum and jnp.maximum.